### PR TITLE
Change to assume all files are in same folder as project exe

### DIFF
--- a/GamingSupervisor/GamingSupervisor/GUI/ReplayHeroSelection.xaml.cs
+++ b/GamingSupervisor/GamingSupervisor/GUI/ReplayHeroSelection.xaml.cs
@@ -34,7 +34,7 @@ namespace GamingSupervisor
             {
                 heros.Add(new HeroListItem()
                 {
-                    ImagePath = Path.Combine(Environment.CurrentDirectory, @"..\..\hero_icon_images\" + replayParse.heroID.ID_heroDictionary[heroName].ToString() + ".png"),
+                    ImagePath = Path.Combine(Environment.CurrentDirectory, "hero_icon_images/" + replayParse.heroID.ID_heroDictionary[heroName].ToString() + ".png"),
                     Title = heroName
                 });
             }

--- a/GamingSupervisor/GamingSupervisor/GUI/ReplaySelection.xaml.cs
+++ b/GamingSupervisor/GamingSupervisor/GUI/ReplaySelection.xaml.cs
@@ -64,7 +64,7 @@ namespace GamingSupervisor
 
                 replays = new List<ReplayListItem>();
                 foreach (string replay in
-                    Directory.EnumerateDirectories(Path.Combine(Environment.CurrentDirectory, "../../Parser/")))
+                    Directory.EnumerateDirectories(Path.Combine(Environment.CurrentDirectory, "Parser")))
                 {
                     var matchResult = await api.GetDetailedMatch(Path.GetFileName(replay));
 
@@ -128,7 +128,7 @@ namespace GamingSupervisor
 
         private void ConfirmSelection(object sender, RoutedEventArgs e)
         {
-            GUISelection.replayDataFolderLocation = Path.Combine("../../Parser", GUISelection.fileName + "/");
+            GUISelection.replayDataFolderLocation = Path.Combine("Parser", GUISelection.fileName + "/");
 
             NavigationService navService = NavigationService.GetNavigationService(this);
             ReplayHeroSelection replayHeroSelection = new ReplayHeroSelection();

--- a/GamingSupervisor/GamingSupervisor/GamingSupervisor.csproj
+++ b/GamingSupervisor/GamingSupervisor/GamingSupervisor.csproj
@@ -250,4 +250,11 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(ProjectDir)Parser\parser.jar" "$(ProjectDir)bin\$(ConfigurationName)" /R /Y
+xcopy "$(ProjectDir)hero_icon_images" "$(ProjectDir)bin\$(ConfigurationName)\hero_icon_images\" /R /Y /I
+xcopy "$(ProjectDir)other_images" "$(ProjectDir)bin\$(ConfigurationName)\other_images\"  /R /Y /I
+xcopy "$(ProjectDir)buttons" "$(ProjectDir)bin\$(ConfigurationName)\buttons\"  /R /Y /I
+xcopy "$(ProjectDir)..\replayParse\Properties" "$(ProjectDir)bin\$(ConfigurationName)\Properties\"  /R /Y /I</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/GamingSupervisor/GamingSupervisor/ParserHandler.cs
+++ b/GamingSupervisor/GamingSupervisor/ParserHandler.cs
@@ -51,7 +51,7 @@ namespace GamingSupervisor
         private static void ParseReplay(string replayLocation, string arg)
         {
             string directoryPath = Path.Combine(Environment.CurrentDirectory,
-                "../../Parser/",
+                "Parser",
                 Path.GetFileNameWithoutExtension(replayLocation));
             string fileName = Path.GetFileName(replayLocation);
 
@@ -68,7 +68,7 @@ namespace GamingSupervisor
             p.StartInfo.FileName = "javaw";
             p.StartInfo.Arguments =
                 "-jar "
-                + '"' + Path.Combine(Environment.CurrentDirectory, "../../Parser/parser.jar") + '"'
+                + '"' + Path.Combine(Environment.CurrentDirectory, "parser.jar") + '"'
                 + " "
                 + '"' + replayLocation.Replace(@"\", "/") + '"' // Replay .dem location
                 + " "

--- a/GamingSupervisor/Yato.DirectXOverlay/Direct2DRenderer.cs
+++ b/GamingSupervisor/Yato.DirectXOverlay/Direct2DRenderer.cs
@@ -1463,7 +1463,7 @@ namespace Yato.DirectXOverlay
 
         public void SelectedHeroSuggestion(int HeroID, float mouse_Y)
         {
-            string file = Path.Combine(Environment.CurrentDirectory, @"..\..\..\replayParse\Properties\hero_difficulty_version_1.txt");
+            string file = Path.Combine(Environment.CurrentDirectory, "Properties/hero_difficulty_version_1.txt");
             hero_difficulty dt = new hero_difficulty(file);
             string suggestion = dt.mainDiff(HeroID);
             string hero_rating = dt.getFinalLevel(HeroID)[0] + ": " + dt.getFinalLevel(HeroID)[1] + "\n\n";
@@ -1588,7 +1588,7 @@ namespace Yato.DirectXOverlay
         // one of the five suggested heroes get banned by the other team
         public void SuggestedHeroBanned(int heroIndex)
         {
-            Direct2DBitmap cross = new Direct2DBitmap(device, @"..\\..\\other_images\red_cross.png");
+            Direct2DBitmap cross = new Direct2DBitmap(device, "other_images/red_cross.png");
             DrawBitmap(cross, 1, messages[heroIndex].img_x, messages[heroIndex].img_y, messages[heroIndex].img_width, messages[heroIndex].img_height);
             cross.SharpDXBitmap.Dispose();
         }
@@ -1596,7 +1596,7 @@ namespace Yato.DirectXOverlay
         // one of the five suggested heroes get picked by our team
         public void SuggestedHeroPicked(int heroIndex)
         {
-            Direct2DBitmap check = new Direct2DBitmap(device, @"..\\..\\other_images\green_check.png");
+            Direct2DBitmap check = new Direct2DBitmap(device, "other_images/green_check.png");
             DrawBitmap(check, 1, messages[heroIndex].img_x, messages[heroIndex].img_y, messages[heroIndex].img_width, messages[heroIndex].img_height);
             check.SharpDXBitmap.Dispose();
         }
@@ -1618,7 +1618,7 @@ namespace Yato.DirectXOverlay
                         DrawTextWithBackground(messages[i].text, messages[i].x, messages[i].y, messages[i].font, messages[i].color, messages[i].background);
                         if (messages[i].imgName != "")
                         {
-                            Direct2DBitmap bmp = new Direct2DBitmap(device, @"..\\..\\hero_icon_images\" + messages[i].imgName + ".png");
+                            Direct2DBitmap bmp = new Direct2DBitmap(device, "hero_icon_images/" + messages[i].imgName + ".png");
                             DrawBitmap(bmp, 1, messages[i].img_x, messages[i].img_y, messages[i].img_width, messages[i].img_height);
                             bmp.SharpDXBitmap.Dispose();
                         }
@@ -1756,7 +1756,7 @@ namespace Yato.DirectXOverlay
                         DrawTextWithBackground(messages[i].text, messages[i].x, messages[i].y, messages[i].font, messages[i].color, messages[i].background);
                         if (messages[i].imgName != "")
                         {
-                            Direct2DBitmap bmp = new Direct2DBitmap(device, @"..\\..\\hero_icon_images\" + messages[i].imgName + ".png");
+                            Direct2DBitmap bmp = new Direct2DBitmap(device, "hero_icon_images/" + messages[i].imgName + ".png");
                             DrawBitmap(bmp, 1, messages[i].img_x, messages[i].img_y, messages[i].img_width, messages[i].img_height);
                             bmp.SharpDXBitmap.Dispose();
                         }
@@ -1816,7 +1816,7 @@ namespace Yato.DirectXOverlay
                 DrawTextWithBackground(messages[12].text, messages[12].x, messages[12].y, messages[12].font, messages[12].color, messages[12].background);
                 if (messages[12].imgName != "")
                 {
-                    Direct2DBitmap bmp = new Direct2DBitmap(device, @"..\\..\\hero_icon_images\" + messages[12].imgName + ".png");
+                    Direct2DBitmap bmp = new Direct2DBitmap(device, "hero_icon_images/" + messages[12].imgName + ".png");
                     DrawBitmap(bmp, 1, messages[12].img_x, messages[12].img_y, messages[12].img_width, messages[12].img_height);
                     bmp.SharpDXBitmap.Dispose();
                 }
@@ -1883,7 +1883,7 @@ namespace Yato.DirectXOverlay
                 button_timer.Reset();
             }
 
-            Direct2DBitmap close_button_red = new Direct2DBitmap(device, @"..\\..\\buttons\" + instruction.close_button_red + ".png");
+            Direct2DBitmap close_button_red = new Direct2DBitmap(device, "buttons/" + instruction.close_button_red + ".png");
 
             float scale = button_timer.ElapsedMilliseconds;
             scale = scale / 6000;

--- a/GamingSupervisor/replayParse/counterpick_info.cs
+++ b/GamingSupervisor/replayParse/counterpick_info.cs
@@ -19,7 +19,7 @@ namespace replayParse
             heroID h_ID = new heroID();
             Dictionary<int, string> ID_table = h_ID.getHeroID(); // key is ID, value is hero_name;
             Dictionary<string, int> hero_table = h_ID.getIDHero(); // key is hero_name, value is ID;
-            string s = Path.Combine(Environment.CurrentDirectory, @"..\..\..\replayParse\Properties\c");
+            string s = Path.Combine(Environment.CurrentDirectory, "Properties/c");
             string s_end = ".txt";
             int i = 1;
             string path = "";
@@ -63,7 +63,7 @@ namespace replayParse
                 i++;
             }
 
-            string path1 = Path.Combine(Environment.CurrentDirectory, @"..\..\..\replayParse\Properties\countertable.txt");
+            string path1 = Path.Combine(Environment.CurrentDirectory, "Properties/countertable.txt");
             if (!File.Exists(path1))
             {
                 // Create a file to write to.

--- a/GamingSupervisor/replayParse/heroGenerateTypes.cs
+++ b/GamingSupervisor/replayParse/heroGenerateTypes.cs
@@ -19,7 +19,7 @@ namespace replayParse
          */
         public heroGenerateTypes()
         {
-            string s = Path.Combine(Environment.CurrentDirectory, @"..\..\..\replayParse\Properties\herotype.txt");
+            string s = Path.Combine(Environment.CurrentDirectory, "Properties/herotype.txt");
             string[] lines = System.IO.File.ReadAllLines(s);
             string[] second_lines = lines;
             int index = 0;

--- a/GamingSupervisor/replayParse/heroID.cs
+++ b/GamingSupervisor/replayParse/heroID.cs
@@ -11,7 +11,7 @@ namespace replayParse
         public static string[] heroName = new string[116]; // make the index be the ID value, so the first string is empty
         public heroID()
         {
-            string s = Path.Combine(Environment.CurrentDirectory, @"..\..\..\replayParse\Properties\dota_hero_info_1.txt");
+            string s = Path.Combine(Environment.CurrentDirectory, "Properties/dota_hero_info_1.txt");
             string[] lines = System.IO.File.ReadAllLines(s);
             string[] second_lines = lines;
             int key = 0;
@@ -41,7 +41,7 @@ namespace replayParse
                 heroName[key] = hero_name;
 
             }
-            string path = Path.Combine(Environment.CurrentDirectory, @"..\..\..\replayParse\Properties\heroIDtable.txt");
+            string path = Path.Combine(Environment.CurrentDirectory, "Properties/heroIDtable.txt");
             if (!File.Exists(path))
             {
                 // Create a file to write to.
@@ -85,7 +85,7 @@ namespace replayParse
                 hero_IDDictionary.Add(key, words[0]);
                 ID_heroDictionary.Add(words[0], key);
             }
-            string path = Path.Combine(Environment.CurrentDirectory, @"..\..\Properties\heroIDtable.txt");
+            string path = Path.Combine(Environment.CurrentDirectory, "Properties/heroIDtable.txt");
             if (!File.Exists(path))
             {
                 // Create a file to write to.

--- a/GamingSupervisor/replayParse/heroIDClient.cs
+++ b/GamingSupervisor/replayParse/heroIDClient.cs
@@ -11,7 +11,7 @@ namespace replayParse
         public static string[] heroName = new string[121]; // make the index be the ID value, so the first string is empty
         public heroIDClient()
         {
-            string s = Path.Combine(Environment.CurrentDirectory, @"..\..\..\replayParse\Properties\heroIDtable1.txt");
+            string s = Path.Combine(Environment.CurrentDirectory, "Properties/heroIDtable1.txt");
             string[] lines = System.IO.File.ReadAllLines(s);
             string[] second_lines = lines;
             int key = 0;

--- a/GamingSupervisor/replayParse/hero_difficulty.cs
+++ b/GamingSupervisor/replayParse/hero_difficulty.cs
@@ -66,8 +66,7 @@ namespace replayParse
         public static int[,] difficulty_table = new int[116, 8];
         public hero_difficulty()
         {
-            string s = Path.Combine(Environment.CurrentDirectory,
-                @"..\..\..\replayParse\Properties\hero_difficulty_version_1.txt");
+            string s = Path.Combine(Environment.CurrentDirectory, "Properties/hero_difficulty_version_1.txt");
             string[] lines = File.ReadAllLines(s);
             string[] second_lines = lines;
             int key = 0;

--- a/GamingSupervisor/replayParse/makeup_difficulty-table.cs
+++ b/GamingSupervisor/replayParse/makeup_difficulty-table.cs
@@ -11,7 +11,7 @@ namespace replayParse
     {
         public makeup_difficulty_talbe()
         {
-            string s = Path.Combine(Environment.CurrentDirectory, @"..\..\..\replayParse\Properties\hero_difficulty_version_0.txt");
+            string s = Path.Combine(Environment.CurrentDirectory, "Properties/hero_difficulty_version_0.txt");
             string[] lines = System.IO.File.ReadAllLines(s);
             string[] second_lines = lines;
             int key = 0;
@@ -32,7 +32,7 @@ namespace replayParse
                 key++;
 
             }
-            string path = Path.Combine(Environment.CurrentDirectory, @"..\..\..\replayParse\Properties\hero_difficulty_version_1.txt");
+            string path = Path.Combine(Environment.CurrentDirectory, "Properties/hero_difficulty_version_1.txt");
             if (!File.Exists(path))
             {
                 // Create a file to write to.


### PR DESCRIPTION
-All file paths were changed to assume they are in the same folder as the main .exe (e.g. no more ../../../replayParse).
-When building the project, Visual Studio will now copy all the needed files to the bin folder.

These changes together should make it easier to share the project with others since now all we need to do is zip the bin file.